### PR TITLE
[BUGFIX] Prevent sending empty forms in FormEngine

### DIFF
--- a/typo3/sysext/backend/Resources/Public/JavaScript/jsfunc.tbe_editor.js
+++ b/typo3/sysext/backend/Resources/Public/JavaScript/jsfunc.tbe_editor.js
@@ -268,7 +268,7 @@ var TBE_EDITOR = {
 		// TODO: This should be solved in a better way when this script is refactored.
 		window.setTimeout(function() {
 			document.getElementsByName(TBE_EDITOR.formname).item(0).submit();
-		}, 10);
+		}, 100);
 	},
 	split: function(theStr1, delim, index) {
 		var theStr = ""+theStr1;


### PR DESCRIPTION
In some cases the FormEngine forms are send to the server with empty values.
Please see the issue for more details and testing instructions.

Resolves: #80633
Releases: master
Change-Id: I22ff7365e3dcb85bf6c3bc177f6cde674306ce6c
Reviewed-on: https://review.typo3.org/52315
Tested-by: TYPO3com <no-reply@typo3.com>
Reviewed-by: Christian Kuhn <lolli@schwarzbu.ch>
Tested-by: Christian Kuhn <lolli@schwarzbu.ch>